### PR TITLE
Feat: 메인페이지 구현

### DIFF
--- a/src/components/PokemonCard.tsx
+++ b/src/components/PokemonCard.tsx
@@ -1,0 +1,45 @@
+/** @format */
+
+export default function PokemonCard({ pokemon }) {
+  return (
+    <div>
+      <div>{pokemon.name}</div>
+      <img src={pokemon.sprites.front_default} alt="" />
+
+      <img src={pokemon.sprites.back_default} alt="" />
+
+      <img src={pokemon.sprites.other.dream_world.front_default} alt="" />
+      <img src={pokemon.sprites.other.home.front_default} alt="" />
+      {/* <img src={pokemon.sprites.other.official_artwork.front_default} alt="" /> */}
+      <img src={pokemon.sprites.other.showdown.front_default} alt="" />
+      <img src={pokemon.sprites.other.showdown.back_default} alt="" />
+
+      <p>{pokemon.abilities[0].ability.name}</p>
+
+      <p>height: {pokemon.height}</p>
+      <p>weight: {pokemon.weight}</p>
+
+      <p>
+        {pokemon.stats.map((stat) => (
+          <p>
+            {stat.stat.name}: {stat.base_stat}
+          </p>
+        ))}
+      </p>
+
+      <p>
+        {pokemon.types.map((type) => (
+          <p>{type.type.name}</p>
+        ))}
+      </p>
+      <button className="relative inline-block px-6 py-2 text-white bg-red-500 font-semibold rounded transform skew-y-20 hover:bg-red-600 transition duration-500">
+        <span className="inline-block transform -skew-x-12">
+          고지 상품 보러가기
+        </span>
+        <span className="absolute right-2 top-1/2 transform -translate-y-1/2 text-white">
+          &gt;
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/src/pages/PokemonPage.tsx
+++ b/src/pages/PokemonPage.tsx
@@ -1,5 +1,10 @@
 /** @format */
 
+import {
+  PokemonDetailResponse,
+  PokemonListItem,
+  PokemonListResponse,
+} from "../types/Pokemon";
 import { useEffect, useRef, useState } from "react";
 
 import { Link } from "react-router-dom";
@@ -7,25 +12,27 @@ import PokemonCard from "../components/PokemonCard";
 import axios from "axios";
 
 export default function PokemonPage() {
-  const [pokemonList, setPokemonList] = useState([]);
-  const [currentPage, setCurrentPage] = useState(1);
-  const isFetchingRef = useRef(false);
+  const [pokemonList, setPokemonList] = useState<PokemonDetailResponse[]>([]);
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const isFetchingRef = useRef<boolean>(false);
 
-  const fetchPokemonList = async (page) => {
+  const fetchPokemonList = async (page: number) => {
     if (isFetchingRef.current) return; // 중복 호출 방지
     isFetchingRef.current = true;
 
     const offset = (page - 1) * 20;
 
-    const response = await axios.get(
+    const response = await axios.get<PokemonListResponse>(
       `https://pokeapi.co/api/v2/pokemon?offset=${offset}&limit=10`
     );
 
     const pokemonResults = response.data.results;
 
     const pokemonDetails = await Promise.all(
-      pokemonResults.map(async (pokemon) => {
-        const detailsResponse = await axios.get(pokemon.url);
+      pokemonResults.map(async (pokemon: PokemonListItem) => {
+        const detailsResponse = await axios.get<PokemonDetailResponse>(
+          pokemon.url
+        );
         return detailsResponse.data;
       })
     );
@@ -36,8 +43,6 @@ export default function PokemonPage() {
   useEffect(() => {
     fetchPokemonList(currentPage);
   }, [currentPage]);
-
-  console.log(1, pokemonList);
 
   const fetchmore = () => {
     setCurrentPage((prevPage) => prevPage + 1);

--- a/src/pages/PokemonPage.tsx
+++ b/src/pages/PokemonPage.tsx
@@ -1,0 +1,68 @@
+/** @format */
+
+import { useEffect, useRef, useState } from "react";
+
+import { Link } from "react-router-dom";
+import PokemonCard from "../components/PokemonCard";
+import axios from "axios";
+
+export default function PokemonPage() {
+  const [pokemonList, setPokemonList] = useState([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const isFetchingRef = useRef(false);
+
+  const fetchPokemonList = async (page) => {
+    if (isFetchingRef.current) return; // 중복 호출 방지
+    isFetchingRef.current = true;
+
+    const offset = (page - 1) * 20;
+
+    const response = await axios.get(
+      `https://pokeapi.co/api/v2/pokemon?offset=${offset}&limit=10`
+    );
+
+    const pokemonResults = response.data.results;
+
+    const pokemonDetails = await Promise.all(
+      pokemonResults.map(async (pokemon) => {
+        const detailsResponse = await axios.get(pokemon.url);
+        return detailsResponse.data;
+      })
+    );
+    setPokemonList((prev) => [...prev, ...pokemonDetails]);
+    isFetchingRef.current = false;
+  };
+
+  useEffect(() => {
+    fetchPokemonList(currentPage);
+  }, [currentPage]);
+
+  console.log(1, pokemonList);
+
+  const fetchmore = () => {
+    setCurrentPage((prevPage) => prevPage + 1);
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-4xl font-bold text-center text-blue-700 mb-8">
+        Pokédex
+      </h1>
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+        {pokemonList.map((pokemon) => (
+          <Link key={pokemon.id} to={`/pokemon/${pokemon.id}`}>
+            <PokemonCard pokemon={pokemon} />
+          </Link>
+        ))}
+      </div>
+
+      <button
+        className="mt-8 mx-auto block bg-yellow-400 hover:bg-yellow-500 text-blue-700 font-semibold py-2 px-4 rounded-full transition-colors"
+        onClick={fetchmore}
+      >
+        Load More
+      </button>
+    </div>
+  );
+}

--- a/src/types/Pokemon.ts
+++ b/src/types/Pokemon.ts
@@ -1,0 +1,67 @@
+/** @format */
+
+export interface PokemonDetailResponse {
+  id: number; // 포켓몬 ID
+  name: string; // 포켓몬 이름
+  height: number; // 포켓몬 키 (데시미터 단위)
+  weight: number; // 포켓몬 몸무게 (헥토그램 단위)
+  types: PokemonType[]; // 포켓몬 타입 리스트
+  abilities: PokemonAbility[]; // 포켓몬 능력 리스트
+}
+
+export interface PokemonType {
+  slot: number; // 타입의 슬롯 번호 (순서)
+  type: {
+    name: string; // 타입 이름 (예: grass, poison)
+    url: string; // 타입 상세 정보 URL
+  };
+}
+
+export interface PokemonAbility {
+  is_hidden: boolean; // 숨겨진 능력 여부
+  slot: number; // 능력의 슬롯 번호 (순서)
+  ability: {
+    name: string; // 능력 이름 (예: overgrow, chlorophyll)
+    url: string; // 능력 상세 정보 URL
+  };
+}
+
+// 포켓몬 리스트 API 응답 타입
+export interface PokemonListResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: PokemonListItem[];
+}
+
+export interface PokemonListItem {
+  name: string;
+  url: string;
+}
+
+// 특정 포켓몬 상세 정보 API 응답 타입
+export interface PokemonDetailResponse {
+  id: number;
+  name: string;
+  height: number;
+  weight: number;
+  types: PokemonType[];
+  abilities: PokemonAbility[];
+}
+
+export interface PokemonType {
+  slot: number;
+  type: {
+    name: string;
+    url: string;
+  };
+}
+
+export interface PokemonAbility {
+  is_hidden: boolean;
+  slot: number;
+  ability: {
+    name: string;
+    url: string;
+  };
+}


### PR DESCRIPTION
## 🔎 작업 내용
- 메인페이지 구현
   - 전체 포켓몬 목록을 보여주는 메인페이지 구현
   - `https://pokeapi.co/api/v2/pokemon?offset=${offset}&limit=10` api를 통해 초기 20개 불러오기
   - 초기 데이터 로딩 시 로딩 상태 처리

- `PokemonCard` 컴포넌트 구현
   - 각 포켓몬을 보여주는 카드 UI 구현
   - 포켓몬 이미지, 이름, 번호, 타입 등을 시각적으로 표현
   - 상세 페이지 연동을 고려한 구조 설계

- 타입 지정 작업
   - API 응답 타입을 명확히 하기 위해 TypeScript 타입 정의 추가
   - Pokemon, PokemonListResponse, Type, Stat 등 도메인별 타입 분리
   - 컴포넌트 및 API 함수에서 타입 기반으로 안정성 확보

## 🎯 주요 변경 사항
- MainPage 컴포넌트 구현
   - API에서 포켓몬 리스트 불러오기
   - 리스트 데이터를 기반으로 PokemonCard 렌더링

- PokemonCard 컴포넌트 추가
   - 카드 내부에 포켓몬 정보 시각화
   - hover 스타일 등 기본적인 UI 구성

- API 연동 로직 구현 및 타입 지정
   - axios 기반 비동기 요청
   - 응답 데이터 구조에 맞춘 타입 지정 및 에러 방지
- 전체 코드에 타입 안정성 확보
   - props, 응답값 등에 타입 명확히 지정


## 🚀 기대 효과
✅ 코드 안정성 향상 → API 응답 구조에 맞춘 타입 지정으로 예외 방지

✅ 구성 요소의 재사용성 확보 → PokemonCard는 다른 페이지에서도 재활용 가능

✅ 사용자 경험 향상 → 메인 페이지에서 직관적으로 포켓몬 정보를 확인 가능

✅ 유지보수성 향상 → 타입 기반 개발로 개발 속도 및 오류 대응 능력 향상

