### PR TITLE
Feat: detail page 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "axios": "^1.8.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-router-dom": "^7.4.1"
+        "react-router-dom": "^7.4.1",
+        "recharts": "^2.15.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -281,6 +282,18 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1599,6 +1612,69 @@
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -2115,6 +2191,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2189,8 +2274,128 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -2209,6 +2414,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2233,6 +2444,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dunder-proto": {
@@ -2555,12 +2776,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -2936,6 +3172,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2989,7 +3234,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3320,12 +3564,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -3448,6 +3710,15 @@
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3600,6 +3871,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3658,6 +3946,12 @@
         "react": "^19.0.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -3707,6 +4001,75 @@
         "react": ">=18",
         "react-dom": ">=18"
       }
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.2.tgz",
+      "integrity": "sha512-xv9lVztv3ingk7V3Jf05wfAZbM9Q2umJzu5t/cfnAK7LUslNrGT7LPBr74G+ok8kSCeFMaePmWMg0rcYOnczTw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3893,6 +4256,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4014,6 +4383,28 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.8.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.4.1",
         "recharts": "^2.15.2"
       },
@@ -3944,6 +3945,15 @@
       },
       "peerDependencies": {
         "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "axios": "^1.8.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.4.1"
+    "react-router-dom": "^7.4.1",
+    "recharts": "^2.15.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "axios": "^1.8.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.4.1",
     "recharts": "^2.15.2"
   },

--- a/src/components/MoveByRevolution.tsx
+++ b/src/components/MoveByRevolution.tsx
@@ -1,0 +1,26 @@
+/** @format */
+
+import { useNavigate } from "react-router-dom";
+
+export default function MoveByRevolution({ name }) {
+  const navigate = useNavigate();
+
+  const navigateByRebolution = (name) => {
+    navigate(`/pokemon/${name}`);
+  };
+
+  return (
+    <div
+      key={name}
+      className="flex flex-col items-center"
+      onClick={() => navigateByRebolution(name)}
+    >
+      <img
+        src={`https://img.pokemondb.net/artwork/large/${name}.jpg`}
+        alt={name}
+        className="w-28 h-28 object-contain"
+      />
+      <span className="capitalize mt-4 text-lg font-medium">{name}</span>
+    </div>
+  );
+}

--- a/src/components/MoveToHome.tsx
+++ b/src/components/MoveToHome.tsx
@@ -1,0 +1,16 @@
+/** @format */
+
+import { useNavigate } from "react-router-dom";
+
+export default function MoveToHome() {
+  const navigate = useNavigate();
+  const navigatToHome = () => navigate("/");
+  return (
+    <button
+      className="w-full bg-red-500 text-white py-3 font-bold hover:bg-red-600 transition duration-200"
+      onClick={navigatToHome}
+    >
+      Back to PokeDex
+    </button>
+  );
+}

--- a/src/components/MoveToNextPokemon.tsx
+++ b/src/components/MoveToNextPokemon.tsx
@@ -1,0 +1,23 @@
+/** @format */
+
+import { IoArrowForwardCircleOutline } from "react-icons/io5";
+import formatNumber from "../utils/formatNumber";
+import { useNavigate } from "react-router-dom";
+
+export default function MoveToNextPokemon({ pokemon }) {
+  const nextNumber = pokemon.id + 1;
+  const navigate = useNavigate();
+  const navigateByPokemonId = (id) => navigate(`/pokemon/${nextNumber}`);
+
+  return (
+    <div className="flex items-center justify-end w-full lg:w-1/5 p-4 bg-gray-800 text-white hover:bg-gray-900 transition duration-200">
+      <button
+        className="flex items-center gap-3 text-lg justify-center mr-2"
+        onClick={() => navigateByPokemonId(nextNumber)}
+      >
+        No. {formatNumber(nextNumber)}
+        <IoArrowForwardCircleOutline color="red" size={30} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/MoveToPrevPokemon.tsx
+++ b/src/components/MoveToPrevPokemon.tsx
@@ -1,0 +1,23 @@
+/** @format */
+
+import { IoArrowBackCircleOutline } from "react-icons/io5";
+import formatNumber from "../utils/formatNumber";
+import { useNavigate } from "react-router-dom";
+
+export default function MoveToPrevPokemon({ pokemon }) {
+  const prevNumber = pokemon.id - 1;
+  const navigate = useNavigate();
+  const navigateByPokemonId = (id) => navigate(`/pokemon/${prevNumber}`);
+
+  return (
+    <div className="flex items-center justify-between w-full lg:w-1/5 p-4 bg-gray-800 text-white hover:bg-gray-900 transition duration-200">
+      <button
+        className="flex items-center gap-3 text-lg justify-center ml-2"
+        onClick={() => navigateByPokemonId(prevNumber)}
+      >
+        <IoArrowBackCircleOutline color="red" size={30} />
+        No. {formatNumber(prevNumber)}
+      </button>
+    </div>
+  );
+}

--- a/src/components/PokemonImage.tsx
+++ b/src/components/PokemonImage.tsx
@@ -5,33 +5,34 @@ import { RadarTypeColors } from "../types/TypeColor";
 export default function PokemonImage({ pokemon }) {
   const type = pokemon.types?.[0].type.name;
   const colorByType = RadarTypeColors[type];
+
   return (
-    <div className="flex flex-col lg:flex-row items-center justify-center px-4 my-10 py-20">
+    <div className="flex flex-col items-center justify-center">
       {/* 포켓몬 상세 카드 */}
       <div
         className={
-          "bg-white shadow-lg p-6 flex flex-col lg:flex-row items-center w-full max-w-5xl border rounded-tl-[150px] rounded-2xl"
+          "bg-white flex flex-col lg:flex-row justify-center items-center w-full h-full max-w-5xl border rounded-tl-[150px] rounded-2xl px-12 "
         }
         style={{ borderColor: colorByType }}
       >
         {/* 이미지 섹션 */}
-        <div className="w-full lg:w-1/2 flex flex-col justify-center items-center">
+        <div className="w-full flex flex-col justify-center items-center">
           <img
             src={pokemon?.sprites?.other["official-artwork"].front_default}
-            alt=""
+            alt="메인 이미지"
             width={400}
           />
 
-          <div className="flex gap-10 my-10">
+          <div className="flex my-10 w-full justify-between px-10">
             <img
               src={pokemon?.sprites?.other.showdown.front_default}
-              alt=""
-              width={100}
+              alt="앞모습 이미지"
+              width={120}
             />
             <img
               src={pokemon?.sprites?.other.showdown.back_default}
-              alt=""
-              width={100}
+              alt="뒷모습 이미지"
+              width={120}
             />
           </div>
         </div>

--- a/src/components/PokemonImage.tsx
+++ b/src/components/PokemonImage.tsx
@@ -1,0 +1,41 @@
+/** @format */
+
+import { RadarTypeColors } from "../types/TypeColor";
+
+export default function PokemonImage({ pokemon }) {
+  const type = pokemon.types?.[0].type.name;
+  const colorByType = RadarTypeColors[type];
+  return (
+    <div className="flex flex-col lg:flex-row items-center justify-center px-4 my-10 py-20">
+      {/* 포켓몬 상세 카드 */}
+      <div
+        className={
+          "bg-white shadow-lg p-6 flex flex-col lg:flex-row items-center w-full max-w-5xl border rounded-tl-[150px] rounded-2xl"
+        }
+        style={{ borderColor: colorByType }}
+      >
+        {/* 이미지 섹션 */}
+        <div className="w-full lg:w-1/2 flex flex-col justify-center items-center">
+          <img
+            src={pokemon?.sprites?.other["official-artwork"].front_default}
+            alt=""
+            width={400}
+          />
+
+          <div className="flex gap-10 my-10">
+            <img
+              src={pokemon?.sprites?.other.showdown.front_default}
+              alt=""
+              width={100}
+            />
+            <img
+              src={pokemon?.sprites?.other.showdown.back_default}
+              alt=""
+              width={100}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/PokemonInfo.tsx
+++ b/src/components/PokemonInfo.tsx
@@ -1,0 +1,92 @@
+/** @format */
+
+import { RadarTypeColors, typeColors } from "../types/TypeColor";
+
+export default function PokemonInfo({ pokemon }) {
+  const playCry = () => {
+    const audio = new Audio(pokemon?.cries?.latest);
+    audio.play();
+  };
+
+  const type = pokemon.types?.[0].type.name;
+  const colorByType = RadarTypeColors[type];
+
+  return (
+    <div
+      className="rounded-2xl overflow-hidden shadow-md border mx-3"
+      style={{ borderColor: colorByType }}
+    >
+      <table className="bg-white border-collapse w-full">
+        <tbody>
+          {/* 타입 */}
+          <tr className="border-b border-gray-200">
+            <td className="w-48 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
+              타입
+            </td>
+            <td className="px-4 py-4 text-gray-600">
+              {pokemon?.types?.map((typeObj, index) => (
+                <span
+                  key={index}
+                  className={`inline-block px-3 py-1 text-white rounded-full text-sm mr-2 ${
+                    typeColors[typeObj.type.name] || "bg-gray-300"
+                  }`}
+                >
+                  {typeObj.type.name}
+                </span>
+              ))}
+            </td>
+          </tr>
+
+          {/* 키 */}
+          <tr className="border-b border-gray-200">
+            <td className="w-24 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
+              키
+            </td>
+            <td className="px-4 py-4 text-gray-600">{pokemon.height / 10} m</td>
+          </tr>
+
+          {/* 몸무게 */}
+          <tr className="border-b border-gray-200">
+            <td className="w-24 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
+              몸무게
+            </td>
+            <td className="px-4 py-4 text-gray-600">
+              {pokemon.weight / 10} kg
+            </td>
+          </tr>
+
+          {/* 능력 */}
+          <tr>
+            <td className="w-24 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
+              능력
+            </td>
+            <td className="px-4 py-4 text-gray-600">
+              {pokemon?.abilities?.map((ability, index) => (
+                <span
+                  key={index}
+                  className={`inline-block px-3 py-1 rounded-full text-sm mr-2 ${
+                    ability.is_hidden
+                      ? "bg-gray-500 text-white"
+                      : "bg-blue-500 text-white"
+                  }`}
+                >
+                  {ability.ability.name}
+                </span>
+              ))}
+            </td>
+          </tr>
+
+          {/* 몸무게 */}
+          <tr className="border-t border-gray-200">
+            <td className="w-24 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
+              울음소리
+            </td>
+            <td className="px-4 py-4 text-gray-600">
+              <button onClick={playCry}>⚡</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/PokemonInfo.tsx
+++ b/src/components/PokemonInfo.tsx
@@ -1,92 +1,85 @@
 /** @format */
 
-import { RadarTypeColors, typeColors } from "../types/TypeColor";
+import { typeColors } from "../types/TypeColor";
 
-export default function PokemonInfo({ pokemon }) {
+export default function PokemonInfo({ pokemon, colorByType }) {
   const playCry = () => {
     const audio = new Audio(pokemon?.cries?.latest);
     audio.play();
   };
 
-  const type = pokemon.types?.[0].type.name;
-  const colorByType = RadarTypeColors[type];
+  // 정보 배열로 구성
+  const infoItems = [
+    {
+      label: "타입",
+      content: (
+        <div className="flex flex-wrap gap-2">
+          {pokemon?.types?.map((typeObj, index) => (
+            <span
+              key={index}
+              className={`inline-block px-3 py-1 text-white rounded-full text-sm ${
+                typeColors[typeObj.type.name] || "bg-gray-300"
+              }`}
+            >
+              {typeObj.type.name}
+            </span>
+          ))}
+        </div>
+      ),
+    },
+    {
+      label: "키",
+      content: `${pokemon.height / 10} m`,
+    },
+    {
+      label: "몸무게",
+      content: `${pokemon.weight / 10} kg`,
+    },
+    {
+      label: "능력",
+      content: (
+        <div className="flex flex-wrap gap-2">
+          {pokemon?.abilities?.map((ability, index) => (
+            <span
+              key={index}
+              className={`inline-block px-3 py-1 rounded-full text-sm ${
+                ability.is_hidden
+                  ? "bg-gray-500 text-white"
+                  : "bg-blue-500 text-white"
+              }`}
+            >
+              {ability.ability.name}
+            </span>
+          ))}
+        </div>
+      ),
+    },
+    {
+      label: "울음소리",
+      content: (
+        <button onClick={playCry} className="text-xl">
+          ⚡
+        </button>
+      ),
+    },
+  ];
 
   return (
     <div
-      className="rounded-2xl overflow-hidden shadow-md border mx-3"
+      className="rounded-2xl overflow-hidden shadow-md border p-6 space-y-4 bg-white"
       style={{ borderColor: colorByType }}
     >
-      <table className="bg-white border-collapse w-full">
-        <tbody>
-          {/* 타입 */}
-          <tr className="border-b border-gray-200">
-            <td className="w-48 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
-              타입
-            </td>
-            <td className="px-4 py-4 text-gray-600">
-              {pokemon?.types?.map((typeObj, index) => (
-                <span
-                  key={index}
-                  className={`inline-block px-3 py-1 text-white rounded-full text-sm mr-2 ${
-                    typeColors[typeObj.type.name] || "bg-gray-300"
-                  }`}
-                >
-                  {typeObj.type.name}
-                </span>
-              ))}
-            </td>
-          </tr>
-
-          {/* 키 */}
-          <tr className="border-b border-gray-200">
-            <td className="w-24 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
-              키
-            </td>
-            <td className="px-4 py-4 text-gray-600">{pokemon.height / 10} m</td>
-          </tr>
-
-          {/* 몸무게 */}
-          <tr className="border-b border-gray-200">
-            <td className="w-24 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
-              몸무게
-            </td>
-            <td className="px-4 py-4 text-gray-600">
-              {pokemon.weight / 10} kg
-            </td>
-          </tr>
-
-          {/* 능력 */}
-          <tr>
-            <td className="w-24 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
-              능력
-            </td>
-            <td className="px-4 py-4 text-gray-600">
-              {pokemon?.abilities?.map((ability, index) => (
-                <span
-                  key={index}
-                  className={`inline-block px-3 py-1 rounded-full text-sm mr-2 ${
-                    ability.is_hidden
-                      ? "bg-gray-500 text-white"
-                      : "bg-blue-500 text-white"
-                  }`}
-                >
-                  {ability.ability.name}
-                </span>
-              ))}
-            </td>
-          </tr>
-
-          {/* 몸무게 */}
-          <tr className="border-t border-gray-200">
-            <td className="w-24 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
-              울음소리
-            </td>
-            <td className="px-4 py-4 text-gray-600">
-              <button onClick={playCry}>⚡</button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      {infoItems.map((item, index) => (
+        <div
+          key={index}
+          className="flex items-start gap-4 rounded-xl p-4 shadow-sm border border-gray-200"
+        >
+          <div className="w-24 font-bold text-gray-700 text-center">
+            {item.label}
+          </div>
+          <div className="flex-1 text-gray-800 ml-2">{item.content}</div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/components/PokemonName.tsx
+++ b/src/components/PokemonName.tsx
@@ -1,0 +1,31 @@
+/** @format */
+
+import { RadarTypeColors } from "../types/TypeColor";
+import formatNumber from "../utils/formatNumber";
+
+export default function PokemonName({ pokemon, description }) {
+  const type = pokemon.types?.[0].type.name;
+  const colorByType = RadarTypeColors[type];
+  const form = formatNumber;
+  return (
+    <div className="bg-white rounded-2xl px-20">
+      <h2 className="flex flex-col items-start gap-1">
+        <span
+          className="text-2xl font-semibold text-gray-400"
+          style={{ color: colorByType }}
+        >
+          No. {form(pokemon.id)}
+        </span>
+        <span
+          className="text-5xl font-bold capitalize tracking-wide"
+          style={{ color: colorByType }}
+        >
+          {pokemon.name}
+        </span>
+      </h2>
+      <p className="text-gray-700 mt-6 leading-relaxed text-base">
+        {description}
+      </p>
+    </div>
+  );
+}

--- a/src/components/PokemonRadarChart.tsx
+++ b/src/components/PokemonRadarChart.tsx
@@ -1,0 +1,42 @@
+/** @format */
+
+import {
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+  Tooltip,
+} from "recharts";
+
+import { RadarTypeColors } from "../types/TypeColor";
+
+export default function PokemonRadarChart({ pokemon }) {
+  console.log(pokemon);
+  if (!pokemon || !pokemon.stats) {
+    return <div>로딩 중...</div>;
+  }
+
+  const stats = pokemon.stats;
+  const result = stats.map((stat) => ({
+    subject: stat.stat.name,
+    base_stat: stat.base_stat,
+  }));
+  const typeColor = pokemon.types[0].type.name;
+
+  return (
+    <RadarChart outerRadius={90} width={600} height={400} data={result}>
+      <PolarGrid />
+      <PolarAngleAxis dataKey="subject" />
+      <PolarRadiusAxis angle={30} domain={[0, 120]} />
+      <Radar
+        name={pokemon.name}
+        dataKey="base_stat"
+        stroke="#8482ae"
+        fill={RadarTypeColors[typeColor]}
+        fillOpacity={0.5}
+      />
+      <Tooltip />
+    </RadarChart>
+  );
+}

--- a/src/components/PokemonRadarChart.tsx
+++ b/src/components/PokemonRadarChart.tsx
@@ -11,7 +11,7 @@ import {
 
 import { RadarTypeColors } from "../types/TypeColor";
 
-export default function PokemonRadarChart({ pokemon }) {
+export default function PokemonRadarChart({ pokemon, colorByType }) {
   console.log(pokemon);
   if (!pokemon || !pokemon.stats) {
     return <div>로딩 중...</div>;
@@ -25,18 +25,23 @@ export default function PokemonRadarChart({ pokemon }) {
   const typeColor = pokemon.types[0].type.name;
 
   return (
-    <RadarChart outerRadius={90} width={600} height={400} data={result}>
-      <PolarGrid />
-      <PolarAngleAxis dataKey="subject" />
-      <PolarRadiusAxis angle={30} domain={[0, 120]} />
-      <Radar
-        name={pokemon.name}
-        dataKey="base_stat"
-        stroke="#8482ae"
-        fill={RadarTypeColors[typeColor]}
-        fillOpacity={0.5}
-      />
-      <Tooltip />
-    </RadarChart>
+    <div
+      className="bg-white rounded-2xl border"
+      style={{ borderColor: colorByType }}
+    >
+      <RadarChart outerRadius={90} width={500} height={335} data={result}>
+        <PolarGrid />
+        <PolarAngleAxis dataKey="subject" />
+        <PolarRadiusAxis angle={30} domain={[0, 120]} />
+        <Radar
+          name={pokemon.name}
+          dataKey="base_stat"
+          stroke="#8482ae"
+          fill={RadarTypeColors[typeColor]}
+          fillOpacity={0.5}
+        />
+        <Tooltip />
+      </RadarChart>
+    </div>
   );
 }

--- a/src/components/PokemonRevolution.tsx
+++ b/src/components/PokemonRevolution.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import MoveByRevolution from "./MoveByRevolution";
 import axios from "axios";
 
-export default function PokemonRevolution({ pokemon }) {
+export default function PokemonRevolution({ pokemon, colorByType }) {
   const [evolutionList, setEvolutionList] = useState([]);
 
   useEffect(() => {
@@ -42,11 +42,18 @@ export default function PokemonRevolution({ pokemon }) {
 
   return (
     <div className="my-10 flex flex-col items-center">
-      <h2 className="text-2xl font-bold mb-4">Revolution Chain</h2>
-      <div className="flex gap-20 items-center bg-white px-20 py-10 rounded-3xl">
-        {evolutionList.map((name) => (
-          <MoveByRevolution name={name} />
-        ))}
+      <div
+        className="flex flex-col gap-10 items-center bg-white py-10 rounded-3xl border-2"
+        style={{ borderColor: colorByType }}
+      >
+        <h2 className="text-2xl font-bold mb-4 text-gray-500">
+          Revolution Chain
+        </h2>
+        <div className="flex gap-30 w-[1200px] justify-center">
+          {evolutionList.map((name) => (
+            <MoveByRevolution name={name} />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/components/PokemonRevolution.tsx
+++ b/src/components/PokemonRevolution.tsx
@@ -1,0 +1,53 @@
+/** @format */
+
+import { useEffect, useState } from "react";
+
+import MoveByRevolution from "./MoveByRevolution";
+import axios from "axios";
+
+export default function PokemonRevolution({ pokemon }) {
+  const [evolutionList, setEvolutionList] = useState([]);
+
+  useEffect(() => {
+    if (pokemon?.species?.url) {
+      fetchEvolutionChain(pokemon.species.url);
+    }
+  }, [pokemon]);
+
+  const fetchEvolutionChain = async (speciesUrl) => {
+    try {
+      // Step 1: species 요청해서 evolution_chain URL 얻기
+      const speciesRes = await axios.get(speciesUrl);
+      const evoChainUrl = speciesRes.data.evolution_chain.url;
+
+      // Step 2: evolution-chain 요청
+      const evoRes = await axios.get(evoChainUrl);
+      const evoData = evoRes.data;
+
+      // Step 3: 진화 트리 파싱
+      const evoList = [];
+      const traverseChain = (node) => {
+        if (node?.species?.name) {
+          evoList.push(node.species.name);
+          node.evolves_to.forEach(traverseChain);
+        }
+      };
+      traverseChain(evoData.chain);
+
+      setEvolutionList(evoList);
+    } catch (error) {
+      console.error("진화 정보 가져오기 실패:", error);
+    }
+  };
+
+  return (
+    <div className="my-10 flex flex-col items-center">
+      <h2 className="text-2xl font-bold mb-4">Revolution Chain</h2>
+      <div className="flex gap-20 items-center bg-white px-20 py-10 rounded-3xl">
+        {evolutionList.map((name) => (
+          <MoveByRevolution name={name} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/PokemonDetailPage.tsx
+++ b/src/pages/PokemonDetailPage.tsx
@@ -6,6 +6,28 @@ import axios from "axios";
 import { useParams } from "react-router-dom";
 
 export default function PokemonDetailPage() {
+  // 타입별 색상 매핑
+  const typeColors = {
+    bug: "bg-green-500",
+    dark: "bg-gray-800",
+    dragon: "bg-purple-500",
+    electric: "bg-yellow-400",
+    fairy: "bg-pink-400",
+    fighting: "bg-red-600",
+    fire: "bg-orange-500",
+    flying: "bg-blue-300",
+    ghost: "bg-indigo-500",
+    grass: "bg-green-400",
+    ground: "bg-yellow-600",
+    ice: "bg-blue-400",
+    normal: "bg-gray-400",
+    poison: "bg-purple-700",
+    psychic: "bg-pink-600",
+    rock: "bg-yellow-800",
+    steel: "bg-gray-600",
+    water: "bg-blue-500",
+  };
+
   const [pokemon, setPokemon] = useState([]);
   console.log(pokemon);
 
@@ -19,9 +41,6 @@ export default function PokemonDetailPage() {
   };
 
   useEffect(() => fetchPokemonDetailInfo, []);
-
-  const abilityName = pokemon?.abilities?.[0]?.ability?.name;
-  console.log(abilityName); // 데이터가 있으면 출력, 없으면 undefined
 
   return (
     <div className="flex flex-col lg:flex-row items-center justify-between bg-gray-100">
@@ -54,58 +73,83 @@ export default function PokemonDetailPage() {
             </span>
           </div>
 
-          <div className="flex flex-col lg:flex-row items-center justify-center bg-gray-100 px-4 my-10 py-20 rounded-2xl">
-            {/* 포켓몬 상세 카드 */}
-            <div className="bg-white shadow-lg p-6 flex flex-col lg:flex-row items-center w-full max-w-5xl border border-green-400 rounded-tl-[150px] rounded-2xl">
-              {/* 이미지 섹션 */}
-              <div className="w-full lg:w-1/2 flex justify-center items-center">
-                <img
-                  src={pokemon?.sprites?.other.dream_world.front_default}
-                  alt=""
-                  width={400}
-                />
-              </div>
+          <div className="flex">
+            <div className="flex flex-col lg:flex-row items-center justify-center bg-gray-100 px-4 my-10 py-20 rounded-2xl">
+              {/* 포켓몬 상세 카드 */}
+              <div className="bg-white shadow-lg p-6 flex flex-col lg:flex-row items-center w-full max-w-5xl border border-green-400 rounded-tl-[150px] rounded-2xl">
+                {/* 이미지 섹션 */}
+                <div className="w-full lg:w-1/2 flex justify-center items-center">
+                  <img
+                    src={pokemon?.sprites?.other.dream_world.front_default}
+                    alt=""
+                    width={400}
+                  />
+                </div>
+                {/* 상세 정보 테이블 */}
+                <table className="w-full mt-14 bg-gray-100 shadow-md rounded-2xl">
+                  <tbody>
+                    {/* 타입 */}
+                    <tr className="border-b border-gray-200">
+                      <td className="w-48 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
+                        타입
+                      </td>
+                      <td className="px-4 py-4 text-gray-600">
+                        {pokemon?.types?.map((typeObj, index) => (
+                          <span
+                            key={index}
+                            className={`inline-block px-3 py-1 text-white rounded-full text-sm mr-2 ${
+                              typeColors[typeObj.type.name] || "bg-gray-300"
+                            }`}
+                          >
+                            {typeObj.type.name}
+                          </span>
+                        ))}
+                      </td>
+                    </tr>
 
-              {/* 상세 정보 테이블 */}
-              <table className="rounded-2xl w-full bg-white shadow-md mt-10">
-                <tbody>
-                  <tr className="border-b border-gray-200">
-                    <td className="px-4 py-4 font-semibold text-gray-700 flex justify-center border-r-2 border-gray-100 border-t">
-                      키
-                    </td>
-                    <td className="px-4 py-2 text-gray-600">
-                      {pokemon.height / 10} m
-                    </td>
-                  </tr>
-                  <tr className="border-b border-gray-200">
-                    <td className="px-4 py-4 font-semibold text-gray-700 flex justify-center border-r-2 border-gray-100 border-t">
-                      몸무게
-                    </td>
-                    <td className="px-4 py-2 text-gray-600 font-normal">
-                      {pokemon.weight / 10} kg
-                    </td>
-                  </tr>
-                  <tr>
-                    <td className="px-4 py-4 font-semibold text-gray-700 flex justify-center border-r-2 border-gray-100 border-t">
-                      능력
-                    </td>
-                    <td className="px-4 py-2 text-gray-600">
-                      {pokemon?.abilities?.map((ability, index) => (
-                        <span
-                          key={index}
-                          className={`inline-block px-3 py-1 ${
-                            ability.is_hidden
-                              ? "bg-gray-500 text-white"
-                              : "bg-blue-500 text-white"
-                          } rounded-full text-sm mr-2`}
-                        >
-                          {ability.ability.name}
-                        </span>
-                      ))}
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
+                    {/* 키 */}
+                    <tr className="border-b border-gray-200">
+                      <td className="w-24 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
+                        키
+                      </td>
+                      <td className="px-4 py-4 text-gray-600">
+                        {pokemon.height / 10} m
+                      </td>
+                    </tr>
+
+                    {/* 몸무게 */}
+                    <tr className="border-b border-gray-200">
+                      <td className="w-24 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
+                        몸무게
+                      </td>
+                      <td className="px-4 py-4 text-gray-600">
+                        {pokemon.weight / 10} kg
+                      </td>
+                    </tr>
+
+                    {/* 능력 */}
+                    <tr>
+                      <td className="w-24 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
+                        능력
+                      </td>
+                      <td className="px-4 py-4 text-gray-600">
+                        {pokemon?.abilities?.map((ability, index) => (
+                          <span
+                            key={index}
+                            className={`inline-block px-3 py-1 rounded-full text-sm mr-2 ${
+                              ability.is_hidden
+                                ? "bg-gray-500 text-white"
+                                : "bg-blue-500 text-white"
+                            }`}
+                          >
+                            {ability.ability.name}
+                          </span>
+                        ))}
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/PokemonDetailPage.tsx
+++ b/src/pages/PokemonDetailPage.tsx
@@ -1,0 +1,128 @@
+/** @format */
+
+import React, { useEffect, useState } from "react";
+
+import axios from "axios";
+import { useParams } from "react-router-dom";
+
+export default function PokemonDetailPage() {
+  const [pokemon, setPokemon] = useState([]);
+  console.log(pokemon);
+
+  const param = useParams();
+
+  const fetchPokemonDetailInfo = async () => {
+    const response = await axios.get(
+      `https://pokeapi.co/api/v2/pokemon/${param.id}`
+    );
+    setPokemon(response.data);
+  };
+
+  useEffect(() => fetchPokemonDetailInfo, []);
+
+  const abilityName = pokemon?.abilities?.[0]?.ability?.name;
+  console.log(abilityName); // 데이터가 있으면 출력, 없으면 undefined
+
+  return (
+    <div className="flex flex-col lg:flex-row items-center justify-between bg-gray-100">
+      {/* 왼쪽 네비게이션 */}
+      <div className="flex items-center justify-between w-full lg:w-1/5 p-4 bg-gray-800 text-white">
+        <button className="flex items-center gap-2 text-sm">
+          <span className="material-icons">arrow_back</span>
+          No.0001 이상해씨
+        </button>
+      </div>
+
+      {/* 포켓몬 상세 정보 카드 */}
+      <div className="flex flex-col lg:flex-row items-center justify-center w-full lg:w-3/5 bg-white shadow-lg rounded-lg p-6">
+        {/* 텍스트 섹션 */}
+        <div className="w-full lg:w-1/2 mt-6 lg:mt-0">
+          <h2 className="text-xl font-bold">
+            No.{pokemon.id} {pokemon.name}
+          </h2>
+          <p className="text-gray-600 mt-2">
+            햇빛을 받을수록 몸에 힘이 솟아나 등의 꽃봉오리가 커진다.
+          </p>
+
+          {/* 태그 섹션 */}
+          <div className="flex gap-2 mt-4">
+            <span className="px-3 py-1 bg-red-500 text-white rounded-full text-sm">
+              스칼렛
+            </span>
+            <span className="px-3 py-1 bg-gray-300 text-gray-800 rounded-full text-sm">
+              바이올렛
+            </span>
+          </div>
+
+          <div className="flex flex-col lg:flex-row items-center justify-center bg-gray-100 px-4 my-10 py-20 rounded-2xl">
+            {/* 포켓몬 상세 카드 */}
+            <div className="bg-white shadow-lg p-6 flex flex-col lg:flex-row items-center w-full max-w-5xl border border-green-400 rounded-tl-[150px] rounded-2xl">
+              {/* 이미지 섹션 */}
+              <div className="w-full lg:w-1/2 flex justify-center items-center">
+                <img
+                  src={pokemon?.sprites?.other.dream_world.front_default}
+                  alt=""
+                  width={400}
+                />
+              </div>
+
+              {/* 상세 정보 테이블 */}
+              <table className="rounded-2xl w-full bg-white shadow-md mt-10">
+                <tbody>
+                  <tr className="border-b border-gray-200">
+                    <td className="px-4 py-4 font-semibold text-gray-700 flex justify-center border-r-2 border-gray-100 border-t">
+                      키
+                    </td>
+                    <td className="px-4 py-2 text-gray-600">
+                      {pokemon.height / 10} m
+                    </td>
+                  </tr>
+                  <tr className="border-b border-gray-200">
+                    <td className="px-4 py-4 font-semibold text-gray-700 flex justify-center border-r-2 border-gray-100 border-t">
+                      몸무게
+                    </td>
+                    <td className="px-4 py-2 text-gray-600 font-normal">
+                      {pokemon.weight / 10} kg
+                    </td>
+                  </tr>
+                  <tr>
+                    <td className="px-4 py-4 font-semibold text-gray-700 flex justify-center border-r-2 border-gray-100 border-t">
+                      능력
+                    </td>
+                    <td className="px-4 py-2 text-gray-600">
+                      {pokemon?.abilities?.map((ability, index) => (
+                        <span
+                          key={index}
+                          className={`inline-block px-3 py-1 ${
+                            ability.is_hidden
+                              ? "bg-gray-500 text-white"
+                              : "bg-blue-500 text-white"
+                          } rounded-full text-sm mr-2`}
+                        >
+                          {ability.ability.name}
+                        </span>
+                      ))}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
+        {/* 버튼 섹션 */}
+        <button className="mt-6 w-full bg-red-500 text-white py-3 rounded-lg font-bold hover:bg-red-600 transition duration-200">
+          이상해풀 상품 보러가기
+        </button>
+      </div>
+
+      {/* 오른쪽 네비게이션 */}
+      <div className="flex items-center justify-between w-full lg:w-1/5 p-4 bg-gray-800 text-white">
+        <button className="flex items-center gap-2 text-sm ml-auto">
+          No.0003 이상해꽃
+          <span className="material-icons">arrow_forward</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/PokemonDetailPage.tsx
+++ b/src/pages/PokemonDetailPage.tsx
@@ -3,28 +3,46 @@
 import { RadarTypeColors, typeColors } from "../types/TypeColor";
 import { useEffect, useState } from "react";
 
+import PokemonImage from "../components/PokemonImage";
+import PokemonInfo from "../components/PokemonInfo";
 import PokemonRadarChart from "../components/PokemonRadarChart";
+import PokemonRevolution from "../components/PokemonRevolution";
 import axios from "axios";
 import { useParams } from "react-router-dom";
 
 export default function PokemonDetailPage() {
   const [pokemon, setPokemon] = useState([]);
+  const [description, setDescription] = useState("");
 
   const param = useParams();
 
   const fetchPokemonDetailInfo = async () => {
-    const response = await axios.get(
-      `https://pokeapi.co/api/v2/pokemon/${param.id}`
-    );
-    setPokemon(response.data);
+    try {
+      // 1. 포켓몬 기본 정보 요청
+      const response = await axios.get(
+        `https://pokeapi.co/api/v2/pokemon/${param.id}`
+      );
+      const pokemonData = response.data;
+      setPokemon(pokemonData);
+
+      // 2. species 요청 (설명 포함)
+      const speciesResponse = await axios.get(pokemonData.species.url);
+      const speciesData = speciesResponse.data;
+
+      // 3. 한국어 설명 찾기
+      const flavor = speciesData.flavor_text_entries.find(
+        (entry) => entry.language.name === "ko"
+      );
+
+      setDescription(flavor?.flavor_text.replace(/\f/g, " ") || "");
+    } catch (error) {
+      console.error("포켓몬 정보 가져오기 실패:", error);
+    }
   };
 
-  useEffect(() => fetchPokemonDetailInfo, []);
-
-  const playCry = () => {
-    const audio = new Audio(pokemon?.cries?.latest);
-    audio.play();
-  };
+  useEffect(() => {
+    fetchPokemonDetailInfo();
+  }, [param.id]);
 
   const type = pokemon.types?.[0].type.name;
   const colorByType = RadarTypeColors[type];
@@ -40,175 +58,46 @@ export default function PokemonDetailPage() {
       </div>
 
       {/* 포켓몬 상세 정보 카드 */}
-      <div className="flex flex-col lg:flex-row items-center justify-center w-full lg:w-3/5 bg-white shadow-lg rounded-lg p-6">
+      <div className="flex flex-col lg:flex-row items-center justify-center w-full lg:w-3/5 bg-white shadow-lg rounded-lg">
         {/* 텍스트 섹션 */}
         <div className="w-full lg:w-1/2 mt-6 lg:mt-0">
-          <h2
-            className="text-xl font-bold flex flex-col"
-            style={{ color: colorByType || "black" }}
-          >
-            <span>No.{pokemon.id}</span>
-            <span className="text-4xl">{pokemon.name}</span>
-          </h2>
-          <p className="text-gray-600 mt-2">
-            햇빛을 받을수록 몸에 힘이 솟아나 등의 꽃봉오리가 커진다.
-          </p>
-
+          <div className="p-6 bg-white rounded-2xl shadow-md">
+            <h2 className="flex flex-col items-start gap-1">
+              <span
+                className="text-2xl font-semibold text-gray-400"
+                style={{ color: colorByType }}
+              >
+                No. {pokemon.id}
+              </span>
+              <span
+                className="text-5xl font-bold capitalize tracking-wide"
+                style={{ color: colorByType }}
+              >
+                {pokemon.name}
+              </span>
+            </h2>
+            <p className="text-gray-700 mt-4 leading-relaxed text-base">
+              {description}
+            </p>
+          </div>
           {/* 태그 섹션 */}
-          <div className="flex gap-2 mt-4">
+          {/* <div className="flex gap-2 mt-4">
             <span className="px-3 py-1 bg-red-500 text-white rounded-full text-sm">
               스칼렛
             </span>
             <span className="px-3 py-1 bg-gray-300 text-gray-800 rounded-full text-sm">
               바이올렛
             </span>
-          </div>
-
-          <div className="flex w-screen items-center justify-center bg-[url('/bg_pattern.jpg')]">
-            <div className="flex flex-col lg:flex-row items-center justify-center px-4 my-10 py-20">
-              {/* 포켓몬 상세 카드 */}
-              <div
-                className={
-                  "bg-white shadow-lg p-6 flex flex-col lg:flex-row items-center w-full max-w-5xl border rounded-tl-[150px] rounded-2xl"
-                }
-                style={{ borderColor: colorByType }}
-              >
-                {/* 이미지 섹션 */}
-                <div className="w-full lg:w-1/2 flex flex-col justify-center items-center">
-                  <img
-                    src={
-                      pokemon?.sprites?.other["official-artwork"].front_default
-                    }
-                    alt=""
-                    width={400}
-                  />
-
-                  <div className="flex gap-10 my-10">
-                    <img
-                      src={pokemon?.sprites?.other.showdown.front_default}
-                      alt=""
-                      width={100}
-                    />
-                    <img
-                      src={pokemon?.sprites?.other.showdown.back_default}
-                      alt=""
-                      width={100}
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div className="p-6">
-              {/* 상세 정보 테이블 */}
-              <div
-                className="rounded-2xl overflow-hidden shadow-md border mx-3"
-                style={{ borderColor: colorByType }}
-              >
-                <table className="bg-white border-collapse w-full">
-                  <tbody>
-                    {/* 타입 */}
-                    <tr className="border-b border-gray-200">
-                      <td className="w-48 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
-                        타입
-                      </td>
-                      <td className="px-4 py-4 text-gray-600">
-                        {pokemon?.types?.map((typeObj, index) => (
-                          <span
-                            key={index}
-                            className={`inline-block px-3 py-1 text-white rounded-full text-sm mr-2 ${
-                              typeColors[typeObj.type.name] || "bg-gray-300"
-                            }`}
-                          >
-                            {typeObj.type.name}
-                          </span>
-                        ))}
-                      </td>
-                    </tr>
-
-                    {/* 키 */}
-                    <tr className="border-b border-gray-200">
-                      <td className="w-24 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
-                        키
-                      </td>
-                      <td className="px-4 py-4 text-gray-600">
-                        {pokemon.height / 10} m
-                      </td>
-                    </tr>
-
-                    {/* 몸무게 */}
-                    <tr className="border-b border-gray-200">
-                      <td className="w-24 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
-                        몸무게
-                      </td>
-                      <td className="px-4 py-4 text-gray-600">
-                        {pokemon.weight / 10} kg
-                      </td>
-                    </tr>
-
-                    {/* 능력 */}
-                    <tr>
-                      <td className="w-24 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
-                        능력
-                      </td>
-                      <td className="px-4 py-4 text-gray-600">
-                        {pokemon?.abilities?.map((ability, index) => (
-                          <span
-                            key={index}
-                            className={`inline-block px-3 py-1 rounded-full text-sm mr-2 ${
-                              ability.is_hidden
-                                ? "bg-gray-500 text-white"
-                                : "bg-blue-500 text-white"
-                            }`}
-                          >
-                            {ability.ability.name}
-                          </span>
-                        ))}
-                      </td>
-                    </tr>
-
-                    {/* 몸무게 */}
-                    <tr className="border-t border-gray-200">
-                      <td className="w-24 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
-                        울음소리
-                      </td>
-                      <td className="px-4 py-4 text-gray-600">
-                        <button onClick={playCry}>⚡</button>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-              <div
-                className="bg-white rounded-2xl m-3 border"
-                style={{ borderColor: colorByType }}
-              >
+          </div> */}
+          <div className="w-screen bg-[url('/bg_pattern.jpg')] flex justify-center items-center flex-col py-10">
+            <div className="flex items-center justify-center w-[1200px] bg-white rounded-4xl">
+              <PokemonImage pokemon={pokemon} />
+              <div>
+                <PokemonInfo pokemon={pokemon} />
                 <PokemonRadarChart pokemon={pokemon} />
               </div>
             </div>
-            {/* <table className="w-full mt-10 bg-white shadow-md rounded-2xl">
-              <thead>
-                <tr className="bg-gray-100 text-gray-700 text-left">
-                  <th className="px-4 py-3 border-b">스탯 이름</th>
-                  <th className="px-4 py-3 border-b">기본 수치 (base_stat)</th>
-                  <th className="px-4 py-3 border-b">Effort</th>
-                </tr>
-              </thead>
-              <tbody>
-                {pokemon?.stats?.map((statObj, index) => (
-                  <tr key={index} className="border-b">
-                    <td className="px-4 py-3 text-gray-700">
-                      {statObj.stat.name}
-                    </td>
-                    <td className="px-4 py-3 text-gray-600">
-                      {statObj.base_stat}
-                    </td>
-                    <td className="px-4 py-3 text-gray-600">
-                      {statObj.effort}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>{" "} */}
+            <PokemonRevolution pokemon={pokemon} />
           </div>
         </div>
 

--- a/src/pages/PokemonDetailPage.tsx
+++ b/src/pages/PokemonDetailPage.tsx
@@ -42,6 +42,11 @@ export default function PokemonDetailPage() {
 
   useEffect(() => fetchPokemonDetailInfo, []);
 
+  const playCry = () => {
+    const audio = new Audio(pokemon?.cries?.latest);
+    audio.play();
+  };
+
   return (
     <div className="flex flex-col lg:flex-row items-center justify-between bg-gray-100">
       {/* 왼쪽 네비게이션 */}
@@ -145,6 +150,16 @@ export default function PokemonDetailPage() {
                             {ability.ability.name}
                           </span>
                         ))}
+                      </td>
+                    </tr>
+
+                    {/* 울음소리 */}
+                    <tr className="border-t border-gray-200">
+                      <td className="w-24 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
+                        울음소리
+                      </td>
+                      <td className="px-4 py-4 text-gray-600">
+                        <button onClick={playCry}>⚡</button>
                       </td>
                     </tr>
                   </tbody>

--- a/src/pages/PokemonDetailPage.tsx
+++ b/src/pages/PokemonDetailPage.tsx
@@ -1,35 +1,14 @@
 /** @format */
 
-import React, { useEffect, useState } from "react";
+import { RadarTypeColors, typeColors } from "../types/TypeColor";
+import { useEffect, useState } from "react";
 
+import PokemonRadarChart from "../components/PokemonRadarChart";
 import axios from "axios";
 import { useParams } from "react-router-dom";
 
 export default function PokemonDetailPage() {
-  // 타입별 색상 매핑
-  const typeColors = {
-    bug: "bg-green-500",
-    dark: "bg-gray-800",
-    dragon: "bg-purple-500",
-    electric: "bg-yellow-400",
-    fairy: "bg-pink-400",
-    fighting: "bg-red-600",
-    fire: "bg-orange-500",
-    flying: "bg-blue-300",
-    ghost: "bg-indigo-500",
-    grass: "bg-green-400",
-    ground: "bg-yellow-600",
-    ice: "bg-blue-400",
-    normal: "bg-gray-400",
-    poison: "bg-purple-700",
-    psychic: "bg-pink-600",
-    rock: "bg-yellow-800",
-    steel: "bg-gray-600",
-    water: "bg-blue-500",
-  };
-
   const [pokemon, setPokemon] = useState([]);
-  console.log(pokemon);
 
   const param = useParams();
 
@@ -47,6 +26,9 @@ export default function PokemonDetailPage() {
     audio.play();
   };
 
+  const type = pokemon.types?.[0].type.name;
+  const colorByType = RadarTypeColors[type];
+
   return (
     <div className="flex flex-col lg:flex-row items-center justify-between bg-gray-100">
       {/* 왼쪽 네비게이션 */}
@@ -61,7 +43,10 @@ export default function PokemonDetailPage() {
       <div className="flex flex-col lg:flex-row items-center justify-center w-full lg:w-3/5 bg-white shadow-lg rounded-lg p-6">
         {/* 텍스트 섹션 */}
         <div className="w-full lg:w-1/2 mt-6 lg:mt-0">
-          <h2 className="text-xl font-bold">
+          <h2
+            className="text-xl font-bold"
+            style={{ color: colorByType || "black" }}
+          >
             No.{pokemon.id} {pokemon.name}
           </h2>
           <p className="text-gray-600 mt-2">
@@ -78,20 +63,47 @@ export default function PokemonDetailPage() {
             </span>
           </div>
 
-          <div className="flex">
-            <div className="flex flex-col lg:flex-row items-center justify-center bg-gray-100 px-4 my-10 py-20 rounded-2xl">
+          <div className="flex w-screen bg-blue-50 items-center justify-center">
+            <div className="flex flex-col lg:flex-row items-center justify-center px-4 my-10 py-20">
               {/* 포켓몬 상세 카드 */}
-              <div className="bg-white shadow-lg p-6 flex flex-col lg:flex-row items-center w-full max-w-5xl border border-green-400 rounded-tl-[150px] rounded-2xl">
+              <div
+                className={
+                  "bg-white shadow-lg p-6 flex flex-col lg:flex-row items-center w-full max-w-5xl border rounded-tl-[150px] rounded-2xl"
+                }
+                style={{ borderColor: colorByType }}
+              >
                 {/* 이미지 섹션 */}
-                <div className="w-full lg:w-1/2 flex justify-center items-center">
+                <div className="w-full lg:w-1/2 flex flex-col justify-center items-center">
                   <img
-                    src={pokemon?.sprites?.other.dream_world.front_default}
+                    src={
+                      pokemon?.sprites?.other["official-artwork"].front_default
+                    }
                     alt=""
                     width={400}
                   />
+
+                  <div className="flex gap-10 my-10">
+                    <img
+                      src={pokemon?.sprites?.other.showdown.front_default}
+                      alt=""
+                      width={100}
+                    />
+                    <img
+                      src={pokemon?.sprites?.other.showdown.back_default}
+                      alt=""
+                      width={100}
+                    />
+                  </div>
                 </div>
-                {/* 상세 정보 테이블 */}
-                <table className="w-full mt-14 bg-gray-100 shadow-md rounded-2xl">
+              </div>
+            </div>
+            <div className="p-6">
+              {/* 상세 정보 테이블 */}
+              <div
+                className="rounded-2xl overflow-hidden shadow-md border mx-3"
+                style={{ borderColor: colorByType }}
+              >
+                <table className="bg-white border-collapse w-full">
                   <tbody>
                     {/* 타입 */}
                     <tr className="border-b border-gray-200">
@@ -165,8 +177,14 @@ export default function PokemonDetailPage() {
                   </tbody>
                 </table>
               </div>
+              <div
+                className="bg-white rounded-2xl m-3 border"
+                style={{ borderColor: colorByType }}
+              >
+                <PokemonRadarChart pokemon={pokemon} />
+              </div>
             </div>
-            <table className="w-full mt-10 bg-white shadow-md rounded-2xl">
+            {/* <table className="w-full mt-10 bg-white shadow-md rounded-2xl">
               <thead>
                 <tr className="bg-gray-100 text-gray-700 text-left">
                   <th className="px-4 py-3 border-b">스탯 이름</th>
@@ -189,7 +207,7 @@ export default function PokemonDetailPage() {
                   </tr>
                 ))}
               </tbody>
-            </table>{" "}
+            </table>{" "} */}
           </div>
         </div>
 

--- a/src/pages/PokemonDetailPage.tsx
+++ b/src/pages/PokemonDetailPage.tsx
@@ -153,7 +153,7 @@ export default function PokemonDetailPage() {
                       </td>
                     </tr>
 
-                    {/* 울음소리 */}
+                    {/* 몸무게 */}
                     <tr className="border-t border-gray-200">
                       <td className="w-24 px-4 py-4 font-semibold text-gray-700 text-center border-r border-gray-200">
                         울음소리
@@ -166,6 +166,30 @@ export default function PokemonDetailPage() {
                 </table>
               </div>
             </div>
+            <table className="w-full mt-10 bg-white shadow-md rounded-2xl">
+              <thead>
+                <tr className="bg-gray-100 text-gray-700 text-left">
+                  <th className="px-4 py-3 border-b">스탯 이름</th>
+                  <th className="px-4 py-3 border-b">기본 수치 (base_stat)</th>
+                  <th className="px-4 py-3 border-b">Effort</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pokemon?.stats?.map((statObj, index) => (
+                  <tr key={index} className="border-b">
+                    <td className="px-4 py-3 text-gray-700">
+                      {statObj.stat.name}
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">
+                      {statObj.base_stat}
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">
+                      {statObj.effort}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>{" "}
           </div>
         </div>
 

--- a/src/pages/PokemonDetailPage.tsx
+++ b/src/pages/PokemonDetailPage.tsx
@@ -44,10 +44,11 @@ export default function PokemonDetailPage() {
         {/* 텍스트 섹션 */}
         <div className="w-full lg:w-1/2 mt-6 lg:mt-0">
           <h2
-            className="text-xl font-bold"
+            className="text-xl font-bold flex flex-col"
             style={{ color: colorByType || "black" }}
           >
-            No.{pokemon.id} {pokemon.name}
+            <span>No.{pokemon.id}</span>
+            <span className="text-4xl">{pokemon.name}</span>
           </h2>
           <p className="text-gray-600 mt-2">
             햇빛을 받을수록 몸에 힘이 솟아나 등의 꽃봉오리가 커진다.
@@ -63,7 +64,7 @@ export default function PokemonDetailPage() {
             </span>
           </div>
 
-          <div className="flex w-screen bg-blue-50 items-center justify-center">
+          <div className="flex w-screen items-center justify-center bg-[url('/bg_pattern.jpg')]">
             <div className="flex flex-col lg:flex-row items-center justify-center px-4 my-10 py-20">
               {/* 포켓몬 상세 카드 */}
               <div

--- a/src/types/TypeColor.ts
+++ b/src/types/TypeColor.ts
@@ -1,0 +1,45 @@
+/** @format */
+
+// 테일윈드용 색상
+export const typeColors = {
+  bug: "bg-green-500",
+  dark: "bg-gray-800",
+  dragon: "bg-purple-500",
+  electric: "bg-yellow-400",
+  fairy: "bg-pink-400",
+  fighting: "bg-red-600",
+  fire: "bg-orange-500",
+  flying: "bg-blue-300",
+  ghost: "bg-indigo-500",
+  grass: "bg-green-400",
+  ground: "bg-yellow-600",
+  ice: "bg-blue-400",
+  normal: "bg-gray-400",
+  poison: "bg-purple-700",
+  psychic: "bg-pink-600",
+  rock: "bg-yellow-800",
+  steel: "bg-gray-600",
+  water: "bg-blue-500",
+};
+
+// 차트용 색상
+export const RadarTypeColors = {
+  bug: "#22c55e", // bg-green-500
+  dark: "#1f2937", // bg-gray-800
+  dragon: "#8b5cf6", // bg-purple-500
+  electric: "#facc15", // bg-yellow-400
+  fairy: "#f472b6", // bg-pink-400
+  fighting: "#dc2626", // bg-red-600
+  fire: "#f97316", // bg-orange-500
+  flying: "#93c5fd", // bg-blue-300
+  ghost: "#6366f1", // bg-indigo-500
+  grass: "#4ade80", // bg-green-400
+  ground: "#ca8a04", // bg-yellow-600
+  ice: "#60a5fa", // bg-blue-400
+  normal: "#9ca3af", // bg-gray-400
+  poison: "#6b21a8", // bg-purple-700
+  psychic: "#db2777", // bg-pink-600
+  rock: "#713f12", // bg-yellow-800
+  steel: "#4b5563", // bg-gray-600
+  water: "#3b82f6", // bg-blue-500
+};


### PR DESCRIPTION
## 🔎 작업 내용  
### 디테일 페이지 및 기능 확장 구현  

- 포켓몬 상세 정보 페이지(`detailPage`) 구현  
- 상단 홈 이동 버튼, 진화 정보, 이미지, 타입별 색상 등 UI 요소 추가  
- 포켓몬 진화 정보 `PokemonRevolution`, `PokemonImage`, `PokemonInfo` 컴포넌트 분리 및 적용  
- 포켓몬 상세 이미지 및 배경 이미지 설정  
- 타입별 색상 지정 및 차트 시각화(`RadarChart`) 구성  
- 차트 라이브러리 설치 및 타입별 색상 매핑 로직 구현  
- 설명 부분 map 렌더링으로 변경  
- 효과음(울음소리) 재생 기능 추가  
- 아이콘용 `react-icons` 설치  
- 관련 CSS 수정  

---

## 🎯 주요 변경 사항  

- `detailPage` 컴포넌트 전체 구현  
  - 상단 이동 로직 및 상세 페이지 라우팅 연동  
  
![image](https://github.com/user-attachments/assets/b1fa1bfb-a6f7-420c-8d1b-0ac3600052ad)

  - 타입 기반의 배경 색상 및 테마 지정  - `TypeColor.ts`
  <img src="https://github.com/user-attachments/assets/26332533-6aa6-4091-b0ff-dab1183f2cda" width="300"/>

  - 진화 정보 등 재렌더링 고려 구조 설계  

- `RadarChart`를 통한 스탯 시각화  
  - 타입별 색상 정의 및 매핑  
  - 차트 라이브러리 도입 및 설정  
  
![image](https://github.com/user-attachments/assets/275fec59-373a-4d0e-9f2f-9d0186510b88)


- `PokemonInfo`, `PokemonImage`, `PokemonRevolution` 컴포넌트화  
  - 각 요소를 독립적인 구성 요소로 분리  
  - props 기반 정보 전달 구조 확립  

- 설명, 울음소리 등 사용자 경험 개선 요소 추가  
- 스타일 개선 및 시각적 완성도 향상  

![screencapture-localhost-5173-pokemon-2-2025-04-12-11_44_23](https://github.com/user-attachments/assets/ade4dd19-c630-4a4c-9f4b-e725af6bacad)


---

## 🚀 기대 효과  

✅ 상세 정보 페이지 제공으로 사용자 경험 향상  
✅ 타입별 색상 및 차트 시각화로 직관적 정보 제공  
✅ 컴포넌트 분리 및 타입 지정으로 유지보수 용이  
✅ 효과음, 배경 등 다양한 요소를 통해 몰입감 상승  
